### PR TITLE
Incremental back-off to circumbent Github abuse detection

### DIFF
--- a/bin/lp2gh-export-and-import
+++ b/bin/lp2gh-export-and-import
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+import tempfile
+import json
+import os
+import sys
+
+BINDIR = os.path.abspath(os.path.join(__file__, os.pardir))
+POSSIBLE_TOPDIR = os.path.normpath(os.path.join(os.path.abspath(sys.argv[0]),
+                                   os.pardir,
+                                   os.pardir))
+if os.path.exists(os.path.join(POSSIBLE_TOPDIR, 'lp2gh', '__init__.py')):
+    sys.path.insert(0, POSSIBLE_TOPDIR)
+
+import gflags
+from github3 import client
+
+from lp2gh import bugs, milestones
+FLAGS = gflags.FLAGS
+
+if __name__ == '__main__':
+  argv = FLAGS(sys.argv)
+  if not FLAGS.project:
+      FLAGS.project = sys.argv[1]
+
+  c = client.Client(FLAGS.username, FLAGS.password)
+  repo = c.repo(FLAGS.repo_user, FLAGS.repo_name)
+  bugs.import_(
+      repo,
+      bugs.export(FLAGS.project),
+      milestones_map=milestones.import_(
+          repo,
+          milestones.export(FLAGS.project),
+          milestones_map={}
+      )
+  )
+
+  if FLAGS.project:
+      sys.argv[1] = FLAGS.project
+  exec open(os.path.join(BINDIR, "lp2gh-export-branches")).read()


### PR DESCRIPTION
When migrating larger projects, Github's abuse detection triggers at some point. To still allow the migration to go on, incrementally back off, and also check the rate limits for the API to check how long we'll have to wait.
